### PR TITLE
[i18n] Add missing textdomains and comments to translators

### DIFF
--- a/email/report-email-footer.php
+++ b/email/report-email-footer.php
@@ -23,13 +23,17 @@
             <td align="center" bgcolor="#f1f1f1" style="padding: 12px 24px; font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif; font-size: 14px; line-height: 20px; color: #666;">
                 <?php if ( !is_plugin_active( 'wp-client-reports-pro/wp_client_reports_pro.php' ) ) : ?>
                     <p style="margin: 0 0 10px;">
-                        <?php printf( __( 'Report created with %1$sWP Client Reports%2$s.', 'wp-client-reports' ), '<a href="https://switchwp.com/plugins/wp-client-reports/?utm_source=email&utm_medium=report&utm_campaign=footer" target="_blank">', '</a>' ); ?>
+                        <?php
+                        /* translators: 1: Open link tag. 2: Close link tag. */
+                        printf( __( 'Report created with %1$sWP Client Reports%2$s.', 'wp-client-reports' ), '<a href="https://switchwp.com/plugins/wp-client-reports/?utm_source=email&utm_medium=report&utm_campaign=footer" target="_blank">', '</a>' );
+                        ?>
                     </p>
                 <?php endif; ?>
                 <p style="margin: 0 0 10px;">
                     <?php
                         $email_footer = get_option( 'wp_client_reports_email_footer', null );
                         if (!$email_footer) {
+                            /* translators: %s: Site link. */
                             $email_footer = sprintf( __( 'This email was sent by an administrator at %s.', 'wp-client-reports' ), '<a href="' . site_url() . '">' . get_bloginfo('name') . '</a>' );
                         }
                         $allowed_html = ['strong' => [], 'em' => [], 'b' => [], 'i' => [], 'a' => ['href' => [] ] ];

--- a/wp_client_reports.php
+++ b/wp_client_reports.php
@@ -1258,7 +1258,7 @@ function wp_client_reports_default_title_render(  ) {
     }
 	?>
 	<input type='text' name='wp_client_reports_default_title' value='<?php echo esc_attr($option); ?>'class="regular-text">
-    <p class="description"><?php _e('You can use [YEAR], [MONTH], and [DATE] shortcodes for automatic replacement.'); ?></p>
+    <p class="description"><?php _e('You can use [YEAR], [MONTH], and [DATE] shortcodes for automatic replacement.','wp-client-reports'); ?></p>
 	<?php
 }
 
@@ -1273,7 +1273,7 @@ function wp_client_reports_default_email_render(  ) {
     }
 	?>
 	<input type='text' name='wp_client_reports_default_email' value='<?php echo esc_attr($option); ?>'class="regular-text">
-    <p class="description"><?php _e('You can comma separate multiple addresses'); ?></p>
+    <p class="description"><?php _e('You can comma separate multiple addresses','wp-client-reports'); ?></p>
 	<?php
 }
 
@@ -1288,7 +1288,7 @@ function wp_client_reports_email_from_render(  ) {
     }
 	?>
 	<input type='text' name='wp_client_reports_email_from' value='<?php echo esc_attr($option); ?>'class="regular-text">
-    <p class="description"><?php _e('Some SMTP and other email plugins will not obey this setting.'); ?></p>
+    <p class="description"><?php _e('Some SMTP and other email plugins will not obey this setting.','wp-client-reports'); ?></p>
 	<?php
 }
 
@@ -1375,7 +1375,7 @@ function wp_client_reports_options_page(  ) {
 	?>
     <div class="wrap" id="wp-client-reports-options">
         <h1 class="wp-heading-inline"><?php _e('WP Client Reports Settings','wp-client-reports'); ?></h1>
-        <a href="<?php echo admin_url( 'index.php?page=wp_client_reports' ); ?>" class="page-title-action"><?php _e('View Reports'); ?></a>
+        <a href="<?php echo admin_url( 'index.php?page=wp_client_reports' ); ?>" class="page-title-action"><?php _e('View Reports','wp-client-reports'); ?></a>
         <form action='options.php' method='post' enctype="multipart/form-data">
             <div id="poststuff">
                 <div id="post-body" class="metabox-holder columns-2">
@@ -1398,11 +1398,11 @@ function wp_client_reports_options_page(  ) {
                                         <?php _e('WP Client Reports Pro offers more branding options and additional reports such as:', 'wp-client-reports'); ?>
                                     </p>
                                     <ul style="list-style: disc;padding-left: 18px;">
-                                        <li><?php _e('Add Logo and Brand Color to Reports'); ?></li>
-                                        <li><?php _e('Google Analytics'); ?></li>
-                                        <li><?php _e('Pingdom & Uptime Robot'); ?></li>
-                                        <li><?php _e('WooCommerce'); ?></li>
-                                        <li><?php _e('Gravity Forms & Ninja Forms'); ?></li>
+                                        <li><?php _e('Add Logo and Brand Color to Reports','wp-client-reports'); ?></li>
+                                        <li><?php _e('Google Analytics','wp-client-reports'); ?></li>
+                                        <li><?php _e('Pingdom & Uptime Robot','wp-client-reports'); ?></li>
+                                        <li><?php _e('WooCommerce','wp-client-reports'); ?></li>
+                                        <li><?php _e('Gravity Forms & Ninja Forms','wp-client-reports'); ?></li>
                                     </ul>
                                     <div><a href="https://switchwp.com/plugins/wp-client-reports/?utm_source=wordpress&utm_medium=plugin_settings&utm_campaign=wpclientreports" class="button" target='_blank'><?php _e('WP Client Reports Pro'); ?></a></div>
                                 </div>

--- a/wp_client_reports.php
+++ b/wp_client_reports.php
@@ -372,15 +372,30 @@ function wp_client_reports_last30_widget_function() {
     <div class="wp-client-reports-big-numbers wp-client-reports-postbox wp-client-reports-last30-widget">
         <div class="wp-client-reports-big-number">
             <h2 id="wp-client-reports-wp-update-count"><?php echo esc_html($updates_data->wp_updated); ?></h2>
-            <h3><?php printf( __( 'WordPress %s Core Updates', 'wp-client-reports' ), '<br>' ); ?></h3>
+            <h3>
+                <?php
+                /* translators: %s: <br> tag. */
+                printf( __( 'WordPress %s Core Updates', 'wp-client-reports' ), '<br>' );
+                ?>
+            </h3>
         </div><!-- .wp-client-reports-big-number -->
         <div class="wp-client-reports-big-number">
             <h2 id="wp-client-reports-theme-update-count"><?php echo esc_html($updates_data->total_themes_updated); ?></h2>
-            <h3><?php printf( __( 'Theme %s Updates', 'wp-client-reports' ), '<br>' ); ?></h3>
+            <h3>
+                <?php
+                /* translators: %s: <br> tag. */
+                printf( __( 'Theme %s Updates', 'wp-client-reports' ), '<br>' );
+                ?>
+            </h3>
         </div><!-- .wp-client-reports-big-number -->
         <div class="wp-client-reports-big-number">
             <h2 id="wp-client-reports-plugin-update-count"><?php echo esc_html($updates_data->total_plugins_updated); ?></h2>
-            <h3><?php printf( __( 'Plugin %s Updates', 'wp-client-reports' ), '<br>' ); ?></h3>
+            <h3>
+                <?php
+                /* translators: %s: <br> tag. */
+                printf( __( 'Plugin %s Updates', 'wp-client-reports' ), '<br>' );
+                ?>
+            </h3>
         </div><!-- .wp-client-reports-big-number -->
     </div><!-- .wp-client-reports-last30-widget -->
 <?php
@@ -496,18 +511,22 @@ function wp_client_reports_stats_page_updates() {
                     <div class="wp-client-reports-big-numbers">
                         <?php 
                             wp_client_reports_render_big_number(
+                                /* translators: %s: <br> tag. */
                                 sprintf( __( 'Total %s Updates', 'wp-client-reports' ), '<br>' ), 
                                 'wp-client-reports-total-update-count'
                             );
                             wp_client_reports_render_big_number(
+                                /* translators: %s: <br> tag. */
                                 sprintf( __( 'WordPress %s Core Updates', 'wp-client-reports' ), '<br>' ), 
                                 'wp-client-reports-wp-update-count'
                             );
                             wp_client_reports_render_big_number(
+                                /* translators: %s: <br> tag. */
                                 sprintf( __( 'Plugin %s Updates', 'wp-client-reports' ), '<br>' ), 
                                 'wp-client-reports-plugin-update-count'
                             );
                             wp_client_reports_render_big_number(
+                                /* translators: %s: <br> tag. */
                                 sprintf( __( 'Theme %s Updates', 'wp-client-reports' ), '<br>' ), 
                                 'wp-client-reports-theme-update-count'
                             );
@@ -735,14 +754,17 @@ function wp_client_reports_stats_page_content() {
                         <div class="wp-client-reports-big-numbers">
                             <?php 
                                 wp_client_reports_render_big_number(
+                                    /* translators: %s: <br> tag. */
                                     sprintf( __( 'Posts %s Added', 'wp-client-reports' ), '<br>' ), 
                                     'wp-client-reports-new-posts-count'
                                 );
                                 wp_client_reports_render_big_number(
+                                    /* translators: %s: <br> tag. */
                                     sprintf( __( 'Pages %s Added', 'wp-client-reports' ), '<br>' ), 
                                     'wp-client-reports-new-pages-count'
                                 );
                                 wp_client_reports_render_big_number(
+                                    /* translators: %s: <br> tag. */
                                     sprintf( __( 'Comments %s Added', 'wp-client-reports' ), '<br>' ), 
                                     'wp-client-reports-new-comments-count'
                                 );
@@ -863,7 +885,8 @@ function wp_client_reports_send_email_report($start, $end, $report_title = null,
     } else {
         $start_date_formatted = $start_date_object->format($date_format);
         $end_date_formatted = $end_date_object->format($date_format);
-        $date_formatted = sprintf( __( 'From %s - %s', 'wp-client-reports' ), esc_html($start_date_formatted), esc_html($end_date_formatted) );
+        /* translators: 1: Start date. 2: End date. */
+        $date_formatted = sprintf( __( 'From %1$s - %2$s', 'wp-client-reports' ), esc_html($start_date_formatted), esc_html($end_date_formatted) );
     }
 
     
@@ -1024,15 +1047,19 @@ function wp_client_reports_stats_email_updates($start_date, $end_date) {
 
     wp_client_reports_render_email_row(
         $updates_data->total_updates, 
+        /* translators: %s: <br> tag. */
         sprintf( __( 'Total %s Updates', 'wp-client-reports' ), '<br>' ), 
         $updates_data->wp_updated, 
+        /* translators: %s: <br> tag. */
         sprintf( __( 'WordPress %s Core Updates', 'wp-client-reports' ), '<br>' )
     );
 
     wp_client_reports_render_email_row(
         $updates_data->total_plugins_updated, 
+        /* translators: %s: <br> tag. */
         sprintf( __( 'Plugin %s Updates', 'wp-client-reports' ), '<br>' ), 
         $updates_data->total_themes_updated, 
+        /* translators: %s: <br> tag. */
         sprintf( __( 'Theme %s Updates', 'wp-client-reports' ), '<br>' )
     );
         
@@ -1101,13 +1128,16 @@ function wp_client_reports_stats_email_content($start_date, $end_date) {
 
     wp_client_reports_render_email_row(
         $content_stats_data->posts_count, 
+        /* translators: %s: <br> tag. */
         sprintf( __( 'Posts %s Added', 'wp-client-reports' ), '<br>' ), 
         $content_stats_data->pages_count, 
+        /* translators: %s: <br> tag. */
         sprintf( __( 'Pages %s Added', 'wp-client-reports' ), '<br>' )
     );
 
     wp_client_reports_render_email_row(
         $content_stats_data->comments_count, 
+        /* translators: %s: <br> tag. */
         sprintf( __( 'Comments %s Added', 'wp-client-reports' ), '<br>' ), 
         null, 
         null


### PR DESCRIPTION
Hi, congrats on this lovely plugin.

I hope you don't mind me opening this PR, I found your plugin very useful and want to retribute with some fixes.

I've translated it to [Portuguese](https://translate.wordpress.org/locale/pt/default/wp-plugins/wp-client-reports/) and fixed some i18n issues like missing textdomains and comments to translators. These comments are essential to understand your use of `<br>` in `%s` variables.

Thanks